### PR TITLE
When trying to set property throws an exception

### DIFF
--- a/src/payment.js
+++ b/src/payment.js
@@ -91,6 +91,7 @@ class Payment {
           // eslint-disable-next-line no-param-reassign
           object.params[prop.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase()] = val;
         }
+        return true;
       },
     });
   }


### PR DESCRIPTION
"Set" trap must return boolean value.
I using the library inside strict code.
[http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver ](http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver )