### PR TITLE
Export signer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 module.exports.Payment = require('./src/payment');
 module.exports.Callback = require('./src/callback');
+module.exports.signer = require('./src/signer');


### PR DESCRIPTION
Making `signer` available for third party greatly increases the reusability of this package. In any cases, you just want to use the signer. 